### PR TITLE
Corrige campos para criação de usuários

### DIFF
--- a/src/Perfil/Perfil.js
+++ b/src/Perfil/Perfil.js
@@ -66,13 +66,12 @@ class Perfil extends Component {
 
     return {
       level: fields.level.value,
-      cnpj: fields.cnpj.value,
-      number: fields.number.value,
+      cnpj: fields.cnpj.value.trim(),
+      number: fields.number.value.trim(),
       politicalParty: fields.politicalParty.value,
-      description: fields.description.value,
-      homologated: false,
+      description: fields.description.value.trim(),
       city: city || fields.city.value,
-      name: name || fields.name.value
+      name: name || fields.name.value.trim()
     };
   };
 

--- a/src/components/CompleteSignup/CompleteSignup.js
+++ b/src/components/CompleteSignup/CompleteSignup.js
@@ -26,7 +26,8 @@ class CompleteSignup extends PureComponent {
     const userMetadata = {
       role: fields.role.value,
       city: city || fields.city.value,
-      name: name || fields.name.value
+      name: name || fields.name.value.trim(),
+      createdAt: new Date().toISOString()
     };
 
     if (userMetadata.role === VOTER) {
@@ -35,11 +36,11 @@ class CompleteSignup extends PureComponent {
 
     const candidateData = {
       level: fields.level.value,
-      cnpj: fields.cnpj.value,
-      number: fields.number.value,
-      politicalParty: fields.politicalParty.value,
-      description: fields.description.value,
-      homologated: false
+      cnpj: fields.cnpj.value.trim(),
+      number: fields.number.value.trim(),
+      politicalParty: fields.politicalParty.value.trim(),
+      description: fields.description.value.trim(),
+      homologated: true
     };
 
     return {


### PR DESCRIPTION
Alterações feitas:
- Apliquei `trim()` nos campos de texto.
- Alterei o campo _homologated_ para `true` por padrão.
- Adicionei o campo _createdAt_ que salva a hora atual em UTC, no formato ISO 8601.