### PR TITLE
Remove busca na collection de fotos

### DIFF
--- a/src/Ranking/Ranking.js
+++ b/src/Ranking/Ranking.js
@@ -64,7 +64,6 @@ class Ranking extends Component {
           .then(doc => {
             if (doc.exists) {
               const candidateDetails = { ...doc.data() };
-              this.getCanditatePicture(candidateDetails.number);
 
               const actualCandidate = {
                 ...candidate,
@@ -81,29 +80,9 @@ class Ranking extends Component {
               console.log('Documento não existe!');
             }
           })
-          .catch(function(error) {
-            console.log('Erro ao tentar coletar o documento:', error);
-          });
+          .catch(console.log);
       });
     });
-  };
-
-  getCanditatePicture = number => {
-    firebase
-      .firestore()
-      .collection('candidates_pictures')
-      .where('number', '==', parseInt(number))
-      .limit(1)
-      .get()
-      .then(querySnapshot => {
-        const { pictures } = this.state;
-        this.setState({
-          pictures: {
-            ...pictures,
-            [number]: querySnapshot.docs[0].data().picture
-          }
-        });
-      });
   };
 
   switchView = view => {
@@ -155,7 +134,6 @@ class Ranking extends Component {
                     <Deputado
                       key={candidate.candidateId}
                       {...candidate}
-                      picture={pictures[candidate.number]}
                     />
                   ))}
 

--- a/src/firebaseSetup.js
+++ b/src/firebaseSetup.js
@@ -1,6 +1,7 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
+import 'firebase/functions';
 
 import currentEnv from './env';
 


### PR DESCRIPTION
Mais cedo já fiz a [migração dos dados](https://github.com/Minhacps/votasp-tse-crawler/blob/master/src/update-pictures.js) cadastrados anteriormente.
Agora não precisamos mais buscar na collection de fotos para montar o ranking, já que esse atributo está junto com o documento em `users`.